### PR TITLE
fix: exit on child exit, rather than close

### DIFF
--- a/bin/node-env-run.ts
+++ b/bin/node-env-run.ts
@@ -32,7 +32,7 @@ function runCommand(
     stdio: 'inherit',
     env: process.env,
   });
-  child.on('close', code => {
+  child.on('exit', code => {
     debug(`Child process exit with code ${code}`);
     process.exit(code);
   });


### PR DESCRIPTION
The child process can finish (and exit) before the `close` event is fired (if another process is sharing the same io streams), and I think node-env-run should exit at that point as well.