### PR TITLE
Dotenv provides it's own stubs definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@types/common-tags": "^1.4.0",
     "@types/debug": "^4.1.5",
-    "@types/dotenv": "^8.2.0",
     "@types/node": "^10.17.28",
     "@types/yargs": "^15.0.5",
     "common-tags": "^1.7.2",


### PR DESCRIPTION
Silences Warning

`npm WARN deprecated @types/dotenv@8.2.0: This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.`